### PR TITLE
Fix and parse json output from llm

### DIFF
--- a/analysis.md
+++ b/analysis.md
@@ -1,0 +1,95 @@
+# Code Analysis: JSON Generation Issues
+
+## Issues Identified
+
+### 1. **Critical Bug: Using Wrong Variable for JSON Parsing**
+**Location**: Line 46
+```python
+data = json.loads(raw.strip())  # ❌ Using raw instead of cleaned
+```
+
+**Problem**: The code calls `fix_json(raw)` and stores the result in `cleaned`, but then tries to parse `raw.strip()` instead of `cleaned`. This completely bypasses the JSON fixing logic.
+
+**Fix**: 
+```python
+data = json.loads(cleaned)  # ✅ Use the cleaned version
+```
+
+### 2. **Model Output Format Issue**
+**Problem**: The `google/flan-t5-xl` model is generating repeated arrays instead of JSON:
+```
+"['10 Best Home Workouts for Beginners', 'Benefits', 'Equipment', 'Sample Routine'], ['10 Best Home Workouts for Beginners', 'Benefits', 'Equipment', 'Sample Routine'], ..."
+```
+
+**Root Causes**:
+- FLAN-T5 is a text-to-text model that may not be optimal for structured JSON generation
+- The model seems to be repeating the same output multiple times
+- The prompt might not be clear enough for this specific model
+
+### 3. **Inadequate JSON Fixing Function**
+**Problem**: The `fix_json()` function doesn't handle cases where the output is completely non-JSON (like arrays or repeated content).
+
+**Current function limitations**:
+- Only fixes minor JSON syntax issues
+- Doesn't handle completely malformed output
+- Doesn't handle array-only outputs
+
+### 4. **Model and Pipeline Choice**
+**Problem**: Using `text2text-generation` with FLAN-T5 for structured output generation may not be optimal.
+
+**Better alternatives**:
+- Use a model specifically fine-tuned for instruction following and JSON generation
+- Consider using `text-generation` pipeline with a more suitable model
+- Use models like `microsoft/DialoGPT-large` or newer instruction-tuned models
+
+### 5. **Prompt Engineering Issues**
+**Problem**: The prompt might not be sufficiently clear for the chosen model.
+
+**Improvements needed**:
+- More explicit JSON format requirements
+- Better examples
+- Clearer structure indicators
+
+## Recommended Fixes
+
+### Immediate Fix (Line 46):
+```python
+# Change this:
+data = json.loads(raw.strip())
+
+# To this:
+data = json.loads(cleaned)
+```
+
+### Enhanced JSON Fixing Function:
+```python
+def fix_json(json_str):
+    """Attempt to fix common JSON issues in LLM outputs."""
+    
+    # Handle completely non-JSON outputs
+    if json_str.startswith('[') and not json_str.strip().startswith('{'):
+        # If it's just arrays, try to construct JSON
+        try:
+            # This is a fallback for array-only outputs
+            return '{"error": "Model generated non-JSON output"}'
+        except:
+            pass
+    
+    # Original fixing logic
+    json_str = re.sub(r'(\w+)(?=\s*":)', r'"\1"', json_str)
+    if not json_str.strip().startswith("{"):
+        json_str = "{" + json_str
+    if not json_str.strip().endswith("}"):
+        json_str = json_str + "}"
+    json_str = re.sub(r',\s*([}\]])', r'\1', json_str)
+    return json_str.strip()
+```
+
+### Better Model Choice:
+Consider switching to a model better suited for structured generation, such as:
+- `microsoft/DialoGPT-large`
+- `facebook/blenderbot-400M-distill`
+- Or use OpenAI's API for more reliable JSON generation
+
+## Root Cause Summary
+The main issue is that FLAN-T5-XL is generating repetitive array content instead of following the JSON format instructions, and the code has a bug where it doesn't use the cleaned output for parsing.

--- a/corrected_generate.py
+++ b/corrected_generate.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+import json
+import sys
+import re
+from transformers import pipeline
+
+def fix_json_correctly(json_str):
+    """Properly fix JSON without over-correcting."""
+    json_str = json_str.strip()
+    
+    # Handle completely non-JSON outputs (like repeated arrays)
+    if json_str.startswith('[') and not json_str.strip().startswith('{'):
+        print("⚠️ Model generated non-JSON output, creating fallback structure")
+        return '{"error": "Model generated non-JSON output"}'
+    
+    # Check if keys are already quoted properly
+    has_quoted_keys = '"title":' in json_str or '"outline":' in json_str or '"intro":' in json_str
+    
+    if has_quoted_keys:
+        # Keys are already quoted, just add braces if missing
+        if not json_str.startswith("{"):
+            json_str = "{" + json_str
+        if not json_str.endswith("}"):
+            json_str = json_str + "}"
+    else:
+        # Keys are not quoted, apply the regex fix
+        json_str = re.sub(r'(\w+)(?=\s*":)', r'"\1"', json_str)
+        if not json_str.startswith("{"):
+            json_str = "{" + json_str
+        if not json_str.endswith("}"):
+            json_str = json_str + "}"
+    
+    # Remove trailing commas
+    json_str = re.sub(r',\s*([}\]])', r'\1', json_str)
+    
+    return json_str
+
+def main():
+    # Read inputs (with defaults)
+    topic = sys.argv[1] if len(sys.argv) > 1 else "Home Workout Routines"
+    tone  = sys.argv[2] if len(sys.argv) > 2 else "Friendly"
+
+    # Load model
+    generator = pipeline(
+        "text2text-generation",
+        model="google/flan-t5-xl",
+        device=-1,
+    )
+
+    # Enhanced prompt
+    prompt = f"""
+    Create a blog post outline in JSON format with these exact fields:
+    - "title" (string): The blog post title
+    - "outline" (array): Exactly 3 main section headings as strings
+    - "intro" (string): A brief introduction paragraph
+    
+    Topic: {topic}
+    Tone: {tone}
+    
+    Example format: {{"title": "Sample Title", "outline": ["Section 1", "Section 2", "Section 3"], "intro": "Introduction text"}}
+    
+    JSON output:
+    """
+
+    # Generate output
+    try:
+        result = generator(prompt, max_new_tokens=300, do_sample=True, temperature=0.7)
+        raw = result[0]["generated_text"]
+        print("Raw output:", repr(raw))
+        
+        # Apply the corrected fix
+        cleaned = fix_json_correctly(raw)
+        print("Cleaned output:", repr(cleaned))
+
+        # Parse JSON - FIXED: Use cleaned instead of raw
+        try:
+            data = json.loads(cleaned)
+            print("\n✅ Successfully parsed JSON:")
+            print(json.dumps(data, indent=2))
+        except json.JSONDecodeError as e:
+            print("❌ Failed to parse JSON:", e)
+            print("Cleaned output was:\n", repr(cleaned))
+            
+            # Fallback
+            print("\n🔄 Creating fallback structure...")
+            fallback = {
+                "title": f"{topic} Guide",
+                "outline": ["Introduction", "Main Content", "Conclusion"],
+                "intro": f"This is a {tone.lower()} guide about {topic.lower()}."
+            }
+            print("Fallback JSON:")
+            print(json.dumps(fallback, indent=2))
+            
+    except Exception as e:
+        print(f"❌ Pipeline error: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/final_summary.md
+++ b/final_summary.md
@@ -1,0 +1,66 @@
+# JSON Generation Issue - Root Cause & Solution
+
+## What Went Wrong
+
+The error you encountered was caused by **two critical bugs** in the original code:
+
+### 1. **Critical Bug: Wrong Variable Used for JSON Parsing** (Line 46)
+```python
+# ❌ WRONG - bypasses the fix_json function entirely
+data = json.loads(raw.strip())
+
+# ✅ CORRECT - uses the cleaned output
+data = json.loads(cleaned)
+```
+
+### 2. **Over-Aggressive Regex in fix_json()** 
+The regex pattern `(\w+)(?=\s*":)` was designed to add quotes to unquoted keys, but it was **incorrectly matching already-quoted keys** and double-quoting them:
+
+**Input**: `"title": "Sample Title", "outline": [...], "intro": "..."`
+**After regex**: `""title"": "Sample Title", ""outline"": [...], ""intro"": "..."`
+
+This created invalid JSON with double quotes: `""title""` instead of `"title"`.
+
+## The Complete Fix
+
+### Fixed Code (`corrected_generate.py`):
+```python
+def fix_json_correctly(json_str):
+    """Properly fix JSON without over-correcting."""
+    json_str = json_str.strip()
+    
+    # Check if keys are already quoted properly
+    has_quoted_keys = '"title":' in json_str or '"outline":' in json_str or '"intro":' in json_str
+    
+    if has_quoted_keys:
+        # Keys are already quoted, just add braces if missing
+        if not json_str.startswith("{"):
+            json_str = "{" + json_str
+        if not json_str.endswith("}"):
+            json_str = json_str + "}"
+    else:
+        # Keys are not quoted, apply the regex fix
+        json_str = re.sub(r'(\w+)(?=\s*":)', r'"\1"', json_str)
+        # Add braces...
+    
+    # Remove trailing commas
+    json_str = re.sub(r',\s*([}\]])', r'\1', json_str)
+    return json_str
+```
+
+### Key Changes:
+1. **Fixed variable usage**: Use `json.loads(cleaned)` instead of `json.loads(raw.strip())`
+2. **Smart regex application**: Only apply the quote-adding regex when keys are actually unquoted
+3. **Better error handling**: More robust fallback mechanisms
+
+## Files Created:
+- `corrected_generate.py` - The fully fixed version of your original script
+- `generate_fixed_v2.py` - Alternative approach with enhanced error handling
+- `simple_fix.py` - Simplified version focusing on the core issues
+- `generate_alternative.py` - Different model approach for more reliable JSON generation
+
+## Testing:
+The debug showed that for the case you encountered, the model was actually generating **nearly perfect JSON** - it just needed braces `{` and `}` added. The over-aggressive regex was breaking perfectly good JSON by double-quoting the keys.
+
+## Recommendation:
+Use `corrected_generate.py` as it specifically handles the exact issue you encountered while maintaining compatibility with other edge cases.

--- a/generate_alternative.py
+++ b/generate_alternative.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+import json
+import sys
+import re
+from transformers import pipeline
+
+def create_fallback_json(topic, tone):
+    """Create a structured JSON response as fallback."""
+    # Simple template-based generation
+    title_templates = {
+        "friendly": f"Your Complete Guide to {topic}",
+        "professional": f"Professional {topic}: A Comprehensive Overview",
+        "casual": f"Everything You Need to Know About {topic}",
+        "expert": f"Advanced {topic}: Expert Insights and Strategies"
+    }
+    
+    title = title_templates.get(tone.lower(), f"{topic}: A {tone} Guide")
+    
+    # Generate outline based on topic keywords
+    if "workout" in topic.lower() or "fitness" in topic.lower():
+        outline = ["Getting Started", "Essential Equipment", "Weekly Schedule"]
+    elif "cooking" in topic.lower() or "recipe" in topic.lower():
+        outline = ["Preparation", "Cooking Techniques", "Serving Suggestions"]
+    else:
+        outline = ["Introduction", "Key Concepts", "Practical Applications"]
+    
+    intro = f"Welcome to this {tone.lower()} guide on {topic.lower()}. Here you'll discover essential information and practical tips to help you succeed."
+    
+    return {
+        "title": title,
+        "outline": outline,
+        "intro": intro
+    }
+
+def extract_json_from_text(text):
+    """Try to extract JSON from generated text using regex."""
+    # Look for JSON-like patterns
+    json_pattern = r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}'
+    matches = re.findall(json_pattern, text)
+    
+    for match in matches:
+        try:
+            # Try to parse each potential JSON block
+            data = json.loads(match)
+            if isinstance(data, dict) and 'title' in data:
+                return data
+        except:
+            continue
+    
+    return None
+
+def main():
+    # Read inputs
+    topic = sys.argv[1] if len(sys.argv) > 1 else "Home Workout Routines"
+    tone  = sys.argv[2] if len(sys.argv) > 2 else "Friendly"
+
+    print(f"🎯 Generating blog outline for: {topic} (Tone: {tone})")
+
+    # Try using a different model approach
+    try:
+        # Use a smaller, more reliable model for text generation
+        generator = pipeline(
+            "text-generation",
+            model="distilgpt2",
+            device=-1,
+            pad_token_id=50256
+        )
+
+        # Create a more structured prompt
+        prompt = f"""Blog post outline in JSON format:
+
+Topic: {topic}
+Tone: {tone}
+
+{{
+  "title": "Complete Guide to {topic}",
+  "outline": [
+    "Getting Started",
+    "Key Points",
+    "Next Steps"
+  ],
+  "intro": "This {tone.lower()} guide covers {topic.lower()}"
+}}
+
+Generate similar JSON for the topic "{topic}" with a {tone.lower()} tone:
+
+{{"""
+
+        # Generate with constrained parameters
+        result = generator(
+            prompt, 
+            max_new_tokens=150,
+            do_sample=True,
+            temperature=0.3,
+            num_return_sequences=1,
+            pad_token_id=50256
+        )
+        
+        raw_output = result[0]["generated_text"]
+        print("Raw model output:", repr(raw_output))
+        
+        # Extract the generated part (remove the prompt)
+        generated_part = raw_output[len(prompt):]
+        full_json = "{" + generated_part
+        
+        print("Extracted JSON attempt:", repr(full_json))
+        
+        # Try to extract valid JSON
+        extracted = extract_json_from_text(full_json)
+        
+        if extracted:
+            print("\n✅ Successfully extracted JSON:")
+            print(json.dumps(extracted, indent=2))
+        else:
+            raise ValueError("Could not extract valid JSON")
+            
+    except Exception as e:
+        print(f"⚠️ Model generation failed: {e}")
+        print("🔄 Using fallback template generation...")
+        
+        # Use template-based fallback
+        fallback_data = create_fallback_json(topic, tone)
+        print("\n✅ Generated using template:")
+        print(json.dumps(fallback_data, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/generate_fixed.py
+++ b/generate_fixed.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import json
+import sys
+import re
+from transformers import pipeline
+
+def fix_json(json_str):
+    """Attempt to fix common JSON issues in LLM outputs."""
+    
+    # Handle completely non-JSON outputs (like repeated arrays)
+    if json_str.startswith('[') and not json_str.strip().startswith('{'):
+        # If it's just arrays, return a fallback structure
+        print("⚠️ Model generated non-JSON output, creating fallback structure")
+        return '{"error": "Model generated non-JSON output", "raw_output": "' + json_str.replace('"', '\\"')[:100] + '..."}'
+    
+    # Fix missing opening quotes for keys
+    json_str = re.sub(r'(\w+)(?=\s*":)', r'"\1"', json_str)
+    # Fix missing opening braces
+    if not json_str.strip().startswith("{"):
+        json_str = "{" + json_str
+    # Fix missing closing braces
+    if not json_str.strip().endswith("}"):
+        json_str = json_str + "}"
+    # Remove trailing commas
+    json_str = re.sub(r',\s*([}\]])', r'\1', json_str)
+    return json_str.strip()
+
+def main():
+    # 1️⃣ Read inputs (with defaults)
+    topic = sys.argv[1] if len(sys.argv) > 1 else "Home Workout Routines"
+    tone  = sys.argv[2] if len(sys.argv) > 2 else "Friendly"
+
+    # 2️⃣ Load an instruction‑tuned model
+    generator = pipeline(
+        "text2text-generation",
+        model="google/flan-t5-xl",
+        device=-1,
+    )
+
+    # 3️⃣ Enhanced prompt for better JSON generation
+    prompt = f"""
+    You must respond with ONLY valid JSON format. No other text.
+    
+    Create a blog post outline with these exact fields:
+    - "title" (string): The blog post title
+    - "outline" (array): Exactly 3 main section headings as strings
+    - "intro" (string): A brief introduction paragraph
+    
+    Topic: {topic}
+    Tone: {tone}
+    
+    Response format (example):
+    {{"title": "Sample Title", "outline": ["Section 1", "Section 2", "Section 3"], "intro": "Introduction text here"}}
+    
+    JSON output:
+    """
+
+    # 4️⃣ Generate raw output
+    try:
+        result = generator(prompt, max_new_tokens=300, do_sample=True, temperature=0.7)
+        raw = result[0]["generated_text"]
+        print("Raw output:", repr(raw))
+        
+        # 5️⃣ Clean the output - FIXED: Use cleaned version for parsing
+        cleaned = fix_json(raw)
+        print("Cleaned output:", repr(cleaned))
+
+        # 6️⃣ Parse JSON - FIXED: Use cleaned instead of raw.strip()
+        try:
+            data = json.loads(cleaned)
+            print("\n✅ Successfully parsed JSON:")
+            print(json.dumps(data, indent=2))
+        except json.JSONDecodeError as e:
+            print("❌ Failed to parse JSON:", e)
+            print("Cleaned output was:\n", repr(cleaned))
+            
+            # Fallback: Create a basic structure manually
+            print("\n🔄 Creating fallback structure...")
+            fallback = {
+                "title": f"{topic} Guide",
+                "outline": ["Introduction", "Main Content", "Conclusion"],
+                "intro": f"This is a {tone.lower()} guide about {topic.lower()}."
+            }
+            print("Fallback JSON:")
+            print(json.dumps(fallback, indent=2))
+            
+    except Exception as e:
+        print(f"❌ Pipeline error: {e}")
+        print("This might be due to model loading issues or insufficient resources.")
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_fixed_v2.py
+++ b/generate_fixed_v2.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+import json
+import sys
+import re
+from transformers import pipeline
+
+def fix_json(json_str):
+    """Attempt to fix common JSON issues in LLM outputs."""
+    
+    # Handle completely non-JSON outputs (like repeated arrays)
+    if json_str.startswith('[') and not json_str.strip().startswith('{'):
+        print("⚠️ Model generated non-JSON output, creating fallback structure")
+        return '{"error": "Model generated non-JSON output", "raw_output": "' + json_str.replace('"', '\\"')[:100] + '..."}'
+    
+    # Clean whitespace
+    json_str = json_str.strip()
+    
+    # FIXED: Only add quotes to unquoted keys, not already quoted ones
+    # This regex looks for word characters that are NOT preceded by a quote and followed by a colon
+    json_str = re.sub(r'(?<!")(\w+)(?=\s*":)', r'"\1"', json_str)
+    
+    # Add missing opening brace
+    if not json_str.startswith("{"):
+        json_str = "{" + json_str
+    
+    # Add missing closing brace
+    if not json_str.endswith("}"):
+        json_str = json_str + "}"
+    
+    # Remove trailing commas before closing brackets/braces
+    json_str = re.sub(r',\s*([}\]])', r'\1', json_str)
+    
+    return json_str
+
+def main():
+    # Read inputs (with defaults)
+    topic = sys.argv[1] if len(sys.argv) > 1 else "Home Workout Routines"
+    tone  = sys.argv[2] if len(sys.argv) > 2 else "Friendly"
+
+    # Load model
+    generator = pipeline(
+        "text2text-generation",
+        model="google/flan-t5-xl",
+        device=-1,
+    )
+
+    # Enhanced prompt for better JSON generation
+    prompt = f"""
+    You must respond with ONLY valid JSON format. No other text.
+    
+    Create a blog post outline with these exact fields:
+    - "title" (string): The blog post title
+    - "outline" (array): Exactly 3 main section headings as strings
+    - "intro" (string): A brief introduction paragraph
+    
+    Topic: {topic}
+    Tone: {tone}
+    
+    Response format (example):
+    {{"title": "Sample Title", "outline": ["Section 1", "Section 2", "Section 3"], "intro": "Introduction text here"}}
+    
+    JSON output:
+    """
+
+    # Generate raw output
+    try:
+        result = generator(prompt, max_new_tokens=300, do_sample=True, temperature=0.7)
+        raw = result[0]["generated_text"]
+        print("Raw output:", repr(raw))
+        
+        # Clean the output
+        cleaned = fix_json(raw)
+        print("Cleaned output:", repr(cleaned))
+
+        # Parse JSON
+        try:
+            data = json.loads(cleaned)
+            print("\n✅ Successfully parsed JSON:")
+            print(json.dumps(data, indent=2))
+        except json.JSONDecodeError as e:
+            print("❌ Failed to parse JSON:", e)
+            print("Cleaned output was:\n", repr(cleaned))
+            
+            # Try a more aggressive fix
+            print("\n🔧 Attempting additional JSON repairs...")
+            
+            # Manual reconstruction if the content looks reasonable
+            if '"title":' in cleaned and '"outline":' in cleaned and '"intro":' in cleaned:
+                try:
+                    # Try to extract individual fields using regex
+                    title_match = re.search(r'"title":\s*"([^"]+)"', cleaned)
+                    outline_match = re.search(r'"outline":\s*(\[[^\]]+\])', cleaned)
+                    intro_match = re.search(r'"intro":\s*"([^"]+)"', cleaned)
+                    
+                    if title_match and outline_match and intro_match:
+                        title = title_match.group(1)
+                        outline_str = outline_match.group(1)
+                        intro = intro_match.group(1)
+                        
+                        # Parse the outline array
+                        outline = json.loads(outline_str)
+                        
+                        reconstructed = {
+                            "title": title,
+                            "outline": outline,
+                            "intro": intro
+                        }
+                        
+                        print("✅ Successfully reconstructed JSON:")
+                        print(json.dumps(reconstructed, indent=2))
+                        return
+                        
+                except Exception as reconstruction_error:
+                    print(f"❌ Reconstruction failed: {reconstruction_error}")
+            
+            # Final fallback
+            print("\n🔄 Creating fallback structure...")
+            fallback = {
+                "title": f"{topic} Guide",
+                "outline": ["Introduction", "Main Content", "Conclusion"],
+                "intro": f"This is a {tone.lower()} guide about {topic.lower()}."
+            }
+            print("Fallback JSON:")
+            print(json.dumps(fallback, indent=2))
+            
+    except Exception as e:
+        print(f"❌ Pipeline error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/simple_fix.py
+++ b/simple_fix.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+import json
+import sys
+import re
+from transformers import pipeline
+
+def fix_json_simple(json_str):
+    """Simple JSON fixer that handles the specific issues we're seeing."""
+    
+    # Clean whitespace
+    json_str = json_str.strip()
+    
+    # Handle case where output is already valid JSON fields but missing braces
+    # Don't try to add quotes if they're already there
+    if not json_str.startswith("{") and ('"title":' in json_str or '"outline":' in json_str):
+        json_str = "{" + json_str
+    
+    if not json_str.endswith("}") and ('"title":' in json_str or '"outline":' in json_str):
+        json_str = json_str + "}"
+    
+    # Remove trailing commas
+    json_str = re.sub(r',\s*([}\]])', r'\1', json_str)
+    
+    # Fix any obvious double-quoting issues
+    json_str = json_str.replace('""', '"')
+    
+    return json_str
+
+def main():
+    topic = sys.argv[1] if len(sys.argv) > 1 else "Home Workout Routines"
+    tone  = sys.argv[2] if len(sys.argv) > 2 else "Friendly"
+
+    generator = pipeline(
+        "text2text-generation",
+        model="google/flan-t5-xl",
+        device=-1,
+    )
+
+    prompt = f"""
+    Create a blog post outline in JSON format with these fields:
+    - "title": blog post title
+    - "outline": array of 3 section headings  
+    - "intro": introduction paragraph
+    
+    Topic: {topic}
+    Tone: {tone}
+    
+    JSON:
+    """
+
+    try:
+        result = generator(prompt, max_new_tokens=200)
+        raw = result[0]["generated_text"]
+        print("Raw output:", repr(raw))
+        
+        # Apply simple fix
+        cleaned = fix_json_simple(raw)
+        print("Cleaned output:", repr(cleaned))
+
+        try:
+            data = json.loads(cleaned)
+            print("\n✅ Success:")
+            print(json.dumps(data, indent=2))
+        except json.JSONDecodeError as e:
+            print("❌ JSON parse error:", e)
+            
+            # Try manual reconstruction for this specific format
+            if '"title":' in raw and '"outline":' in raw and '"intro":' in raw:
+                print("\n🔧 Attempting manual reconstruction...")
+                
+                # Extract values using simple string operations
+                try:
+                    # Find title
+                    title_start = raw.find('"title":') + 8
+                    title_end = raw.find('",', title_start)
+                    if title_end == -1:
+                        title_end = raw.find('"', title_start + 1)
+                    title = raw[title_start:title_end].strip(' "')
+                    
+                    # Find outline array
+                    outline_start = raw.find('"outline":') + 10
+                    outline_end = raw.find(']', outline_start) + 1
+                    outline_str = raw[outline_start:outline_end].strip()
+                    outline = json.loads(outline_str)
+                    
+                    # Find intro
+                    intro_start = raw.find('"intro":') + 8
+                    intro_end = len(raw)
+                    for i in range(intro_start + 1, len(raw)):
+                        if raw[i] == '"' and raw[i-1] != '\\':
+                            intro_end = i
+                            break
+                    intro = raw[intro_start:intro_end].strip(' "')
+                    
+                    reconstructed = {
+                        "title": title,
+                        "outline": outline,
+                        "intro": intro
+                    }
+                    
+                    print("✅ Reconstructed:")
+                    print(json.dumps(reconstructed, indent=2))
+                    
+                except Exception as e2:
+                    print(f"❌ Reconstruction failed: {e2}")
+                    print("Using fallback...")
+                    fallback = {
+                        "title": f"Professional {topic}: A Comprehensive Guide",
+                        "outline": ["Getting Started", "Key Techniques", "Advanced Tips"],
+                        "intro": f"This professional guide provides comprehensive insights into {topic.lower()}."
+                    }
+                    print(json.dumps(fallback, indent=2))
+            
+    except Exception as e:
+        print(f"❌ Error: {e}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Correct JSON parsing to use cleaned output and improve `fix_json` for malformed LLM responses.

The original script failed to parse the LLM's output because it incorrectly used the raw, uncleaned string for `json.loads()`. Additionally, the `fix_json` function was enhanced to better handle cases where the model generated completely non-JSON content (like repeated arrays), providing a more robust parsing mechanism and a fallback.